### PR TITLE
Disable on_post_save hook by default

### DIFF
--- a/TidyTabs.sublime-settings
+++ b/TidyTabs.sublime-settings
@@ -6,5 +6,5 @@
     "tidytabs_accessed_duration": 60,
 
     // Execute tidytabs after save a file
-    "tidytabs_run_on_post_save": "true"
+    "tidytabs_run_on_post_save": false
 }


### PR DESCRIPTION
I did not appreciate tabs randomly closing after SublimePackageControl automatically updated this extension. Even if the setting should be on by default, the setting value shouldn't be a string, as if it is set to `"false"` rather than `false`, it will still be enabled.
